### PR TITLE
adding TypeScript and NuGet sections to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,29 @@
 ## Motivation
 
-The motiviation is to provide a starting point for rapidly building a full-stack
+The motivation is to provide a starting point for rapidly building a full-stack
 single page application leveraging .NET and Entity Framework.
+
+## TypeScript
+
+The project leverages TypeScript 1.6.  To install:
+http://blogs.msdn.com/b/typescript/archive/2015/09/16/announcing-typescript-1-6.aspx
+
+## NuGet Update
+
+To avoid issues with xunit packages, update NuGet:
+https://docs.nuget.org/consume/installing-nuget
+
+## Azure Update
+
+It is recommended that you update to latest version of Visual Studio Tools for Azure:
+
+1. Open Visual Studio.
+2. Go to Tools->Extensions and Updates...
+3. Go to Updates->Visual Studio Gallery
+4. Look for Azure SDK update to install
+
+or download directly:
+https://azure.microsoft.com/en-us/downloads/
 
 ## Installation
 


### PR DESCRIPTION
@christophla I had some issues getting the solution to build, and decided to add the steps I had to take to your readme.  Namely:

1) I did not have TypeScript 1.6 installed.
2) My version of NuGet package manager didn't play well with xunit dependencies.
3) My version of Azure SDK caused a build error.  Upgraded to 2.7.1
